### PR TITLE
Set the build target of the test project to x86 as required by SQLite

### DIFF
--- a/source/NHibernate.AspNet.Identity.Tests/NHibernate.AspNet.Identity.Tests.csproj
+++ b/source/NHibernate.AspNet.Identity.Tests/NHibernate.AspNet.Identity.Tests.csproj
@@ -28,6 +28,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>


### PR DESCRIPTION
Hi Antonio

Here is a very minor fix to the test project as SQLite only runs in 32bit mode.

Thanks
Myles (mcdonnell.myles@gmail.com)